### PR TITLE
Correction du test de la fonction `dedup`

### DIFF
--- a/Chp1/Python - Exercices additionnels.ipynb
+++ b/Chp1/Python - Exercices additionnels.ipynb
@@ -56,7 +56,7 @@
    "outputs": [],
    "source": [
     "L = ['a', 'a', 'b']\n",
-    "assert dedup(L) == ['a' 'b']"
+    "assert dedup(L) == ['a', 'b']"
    ]
   },
   {


### PR DESCRIPTION
La sortie attendue de la fonction `dedup()` est `['5', '4']`, et non pas `['5' '4']`